### PR TITLE
Add option "sonstige" to anschluss calculations

### DIFF
--- a/planprogenerator/model/node.py
+++ b/planprogenerator/model/node.py
@@ -71,6 +71,10 @@ class Node(object):
 
         if other.identifier == self.tip_node.identifier:
             return "Spitze"
+        # In case of two points forming two edges, we should return "Links" AND "Rechts", 
+        # but only "sonstige" is defined as an alternative in the PlanPro definitions..
+        if other.identifier == self.left_node.identifier and other.identifier == self.right_node.identifier:
+            return "sonstige"
         if other.identifier == self.left_node.identifier:
             return "Links"
         if other.identifier == self.right_node.identifier:


### PR DESCRIPTION
This PR will add another option to the identification of node connections ("anschluss"). This is necessary since there are cases where left and right node are the same node.

"_sonstige_" is an option a found in the **PlanPro definition** of the enum, however this might not be the best description of the situation and must be handled accordingly.